### PR TITLE
fix(Build): Build only the database and the backend and manage extension  in the Database

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -23,7 +23,7 @@ docker system prune -f
 docker compose up -d --build postgres backend
 
 echo "Ensure uuid-ossp extension is enabled in Postgres..."
-sleep 10
+sleep 30
 docker compose exec -T postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";'
 
 # === END ===

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -19,8 +19,12 @@ git reset --hard origin/main
 
 echo "Build and create Docker images..."
 docker compose down
-docker system prune -a -f
-docker compose up -d --build
+docker system prune -f
+docker compose up -d --build postgres backend
+
+echo "Ensure uuid-ossp extension is enabled in Postgres..."
+sleep 10
+docker compose exec -T postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";'
 
 # === END ===
 echo "==== END OF DEPLOYEMENT ===="


### PR DESCRIPTION
- Build only the database and the backend:
  - Containers Name: postgres and backend
  
- Add a timeout period before the database is operational (30 seconds)
  
- Adding SQL command when postgres is started:
  - Load activate script to create and load UUID
  `CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`
  
Closes: #140 
